### PR TITLE
修复输入框高度塌陷, 个人中心喜欢列表挤压, 以及 scrollToBottom() 的bug

### DIFF
--- a/src/components/Detail.vue
+++ b/src/components/Detail.vue
@@ -241,8 +241,8 @@ export default {
             // console.log(scrollHeight)
             timer = setInterval(function(){
                 speed += 30;
-                document.body.scrollTop = document.documentElement.scrollTop = this.scrollTop + speed
-                if (document.body.scrollTop >= scrollHeight - 687) {
+                var scrollTop = document.body.scrollTop = document.documentElement.scrollTop = this.scrollTop + speed
+                if (scrollTop >= scrollHeight - 687) {
                     clearInterval(timer)
                     document.body.scrollTop = document.documentElement.scrollTop = scrollHeight
                 }
@@ -250,7 +250,7 @@ export default {
         },
         // 解决键盘抬起遮挡问题(现在是直接滚动到底部评论)
         resetScrollTop(){
-            document.body.scrollTop = document.body.scrollHeight + 600;
+            document.body.scrollTop = document.documentElement.scrollTop = document.body.scrollHeight + 600;
         },
         // 发表评论
         report () {

--- a/src/style/detail.scss
+++ b/src/style/detail.scss
@@ -171,6 +171,8 @@ header{
 		border:1px solid #4ebf60;
 		padding:0 0 0 0.2rem;
 		width: 100%;
+		height: .75rem;
+		line-height: .75rem;
 	}
 	button{
 		border:none;

--- a/src/style/me.scss
+++ b/src/style/me.scss
@@ -104,10 +104,10 @@
 			margin-top: 0.3rem;
 			padding:0 0.4rem;
 			display: flex;
-			overflow: auto;
+			overflow-x: auto;
 			-webkit-overflow-scrolling: touch;
 			li{
-				
+				flex: none
 				& + li{
 					margin-left: 0.2rem;
 				}


### PR DESCRIPTION
1. 在手机端,评论输入框获得焦点或者输入文字后, 输入框的高度会出现塌陷, 给 input 设置固定的高度后就没事

2. 在手机端, 个人中心, 喜欢/不喜欢列表中的影片会挤压,  设置 li { flex: none} 后解决

3. scrollToBottom() 在chrome 中出错, 表现为发表评论后, 页面自动滚动到底部后, 就再也不能滚上去,
原因是给 document.body.scrollTop = xxx 赋值是无效的, 再次访问 document.body.scrollTop 仍然返回 0, 因此定时器将不会被清除, PR中已解决

4. resetScrollTop() 中加上了 document.documentElement.scrollTop 以兼容chrome
resetScrollTop(){
            document.body.scrollTop = document.documentElement.scrollTop = document.body.scrollHeight + 600;
},
